### PR TITLE
Convert package_name from array to string

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,7 +103,7 @@ class pgpool2 (
   validate_absolute_path($confdir)
   validate_string($config_template)
   validate_string($package_ensure)
-  validate_array($package_name)
+  validate_string($package_name)
   validate_bool($service_enable)
 
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -113,7 +113,7 @@ class pgpool2::params {
       $pcp_conf_path          = "${confdir}/pcp.conf"
       $defaults_config        = '/etc/default/pgpool2'
       $config_template        = 'pgpool2/pgpool.conf.erb'
-      $package_name           = [ 'pgpool2' ]
+      $package_name           = 'pgpool2'
       $service_name           = 'pgpool2'
       $pgpool_log_dir         = '/var/log/postgresql'
       $pgpool2_log_conf_path  = "${pgpool_log_dir}/pgpool.log"
@@ -129,7 +129,7 @@ class pgpool2::params {
     #   $pcp_conf_path          = pick($pcp_conf_path, "${confdir}/pcp.conf")
     #   $defaults_config        = '/etc/default/pgpool2'
     #   $config_template        = 'pgpool2/pgpool.conf.erb'
-    #   $package_name           = [ 'pgpool2' ]
+    #   $package_name           = 'pgpool2'
     #   $service_name           = 'pgpool2'
     # }
     default: {


### PR DESCRIPTION
puppet 4 seems to complain if the package_name parameter is an array.
